### PR TITLE
Add shader debug labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,8 @@ async initializePipelines() {
         layout: "auto", 
         compute: {
             module: this.device.createShaderModule({
-                code: SHADERS.add
+                code: SHADERS.add,
+                label: "add"
             }),
         }
     });
@@ -361,7 +362,10 @@ async initializePipelines() {
     this.aggregatePipeline = this.device.createComputePipeline({
         layout: "auto",
         compute: {
-            module: this.device.createShaderModule({ code: SHADERS.aggregate }),
+            module: this.device.createShaderModule({ 
+                code: SHADERS.aggregate,
+                label: "aggregrate" 
+            }),
         }
     });
 }
@@ -533,7 +537,10 @@ First, for the pipeline:
 
 ```javascript
 async initializePipelines() {
-    const imageShaderModule = this.device.createShaderModule({ code: SHADERS.image });
+    const imageShaderModule = this.device.createShaderModule({ 
+        code: SHADERS.image,
+        label: "image"
+    });
     this.imageRenderPipeline = this.device.createRenderPipeline({
         layout: "auto",
         vertex: {
@@ -803,7 +810,10 @@ Now that we have all the buffers set up, we can proceed to creating our **pipeli
 ```javascript
 async initializePipelines() {
     ...
-    const markersShaderModule = this.device.createShaderModule({ code: SHADERS.markers });
+    const markersShaderModule = this.device.createShaderModule({ 
+        code: SHADERS.markers,
+        label: "markers"
+    });
     this.markersRenderPipeline = this.device.createRenderPipeline({
         layout: "auto",
         vertex: {
@@ -1140,7 +1150,10 @@ async initializePipelines() {
     const pipelineDescriptor = {
         layout: this.heatmapComputePipelineLayout,
         compute: {
-            module: this.device.createShaderModule({ code: SHADERS.heatmapCompute }),
+            module: this.device.createShaderModule({ 
+                code: SHADERS.heatmapCompute,
+                label: "heatmapCompute"
+            }),
             entryPoint: "" // Set below for each pipeline
         }
     };
@@ -1312,7 +1325,10 @@ With the shader created, we go back to Javascript and introduce our new **pipeli
 ```javascript
 async initializePipelines() {
     ...
-    const heatmapRenderShaderModule = this.device.createShaderModule({ code: SHADERS.heatmapRender });
+    const heatmapRenderShaderModule = this.device.createShaderModule({ 
+        code: SHADERS.heatmapRender,
+        label: "heatmapRender"
+    });
     this.heatmapRenderPipeline = this.device.createRenderPipeline({
         layout: "auto",
         vertex: {


### PR DESCRIPTION
This adds debug labels to the shaders. Some error messages are better now, like this one

<img width="1628" height="373" alt="grafik" src="https://github.com/user-attachments/assets/1ed0722c-aa7d-4cd3-a253-dac7b6cda17f" />

**Improvements needde**
But honestly, those messages are still quite subpar.
- Chrome: I don't understand why `""add""` has so many quotes
- Firefox: Prints multiple seemingly duplicated error messages. And the error message with the shader code is collapsed by default.

And neither of them have a clicky clicky. I wish I could at least get to the `createShaderModule` call that failed.

**More debug labels needed?**
If any of the messages only involve the pipeline, and not the shader, then the error messages are near useless. Chrome at least includes the name of the shader module, while Firefox does not.

<img width="1956" height="318" alt="grafik" src="https://github.com/user-attachments/assets/1bc6f6f7-7fa3-424c-b8c0-b8fcaae8c689" />

**Bonus**
It is possible, with some sorcery, to make the error messages a lot better and clickable. Should we integrate that?
https://mastodon.social/@stefnotch/114137784233419891
